### PR TITLE
Add Windows build scaffolding and portability shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+build/
+Release/
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+vcpkg_installed/
+vcpkg/
+packages/
+installed/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,15 @@ cmake_minimum_required( VERSION 2.8.13 )
 #Make fast, lean and platform independent binaries..
 #The -fuse-ld=gold flag solves issue https://github.com/FORTH-ModelBasedTracker/MocapNET/issues/34
 #However it causes https://github.com/FORTH-ModelBasedTracker/MocapNET/issues/38
+if (WIN32)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+else()
 set(CMAKE_CXX_FLAGS "-s -O3 -fPIC -march=native -mtune=native") #-fuse-ld=gold
 set(CMAKE_C_FLAGS "-s -O3 -fPIC -march=native -mtune=native") #-fuse-ld=gold
+endif()
+
+add_compile_definitions(_USE_MATH_DEFINES)
 
 OPTION(ENABLE_OPENGL OFF)
 OPTION(INTEL_OPTIMIZATIONS OFF)
@@ -29,7 +36,13 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 #JPEG/PNG libraries..
 set(JPG_Libs jpeg)
-set(PNG_Libs png) 
+set(PNG_Libs png)
+
+if (WIN32)
+  set(MOCAPNET_POSIX_LIBS "")
+else()
+  set(MOCAPNET_POSIX_LIBS rt dl m pthread)
+endif()
 
 
 
@@ -37,10 +50,20 @@ set(PNG_Libs png)
 #------------------------------------------------------------------------------------------------------------------------------------------------
 #First search for Tensorflow 2.x
 #------------------------------------------------------------------------------------------------------------------------------------------------
-IF(EXISTS "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/lib/libtensorflow.so.2")
+IF(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/lib/tensorflow.dll")
+ MESSAGE("Using locally found Windows libtensorflow v2 C-API")
+ set(TENSORFLOW_ROOT "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/lib" CACHE PATH "tensorflow root")
+ set(TENSORFLOW_INCLUDE_ROOT "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/include" CACHE PATH "tensorflow include")
+ set(TENSORFLOW2_FOUND true CACHE BOOL "Tensorflow 2 available")
+ set(TENSORFLOW_SOURCE_FILES
+      ${CMAKE_SOURCE_DIR}/src/NeuralNetworkAbstractionLayer/neuralNetworkAbstraction.cpp
+      ${CMAKE_SOURCE_DIR}/src/Tensorflow/tensorflow.cpp
+      ${CMAKE_SOURCE_DIR}/src/Tensorflow/tf_utils.cpp
+    )
+ELSEIF(EXISTS "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/lib/libtensorflow.so.2")
  MESSAGE("Using locally found libtensorflow v2 C-API")
- set(TENSORFLOW_ROOT "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/lib/" CACHE PATH "tensorflow root") 
- set(TENSORFLOW_INCLUDE_ROOT "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/include/" CACHE PATH "tensorflow include")  
+ set(TENSORFLOW_ROOT "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/lib/" CACHE PATH "tensorflow root")
+ set(TENSORFLOW_INCLUDE_ROOT "${CMAKE_SOURCE_DIR}/dependencies/libtensorflow/include/" CACHE PATH "tensorflow include")
  set(TENSORFLOW2_FOUND true CACHE BOOL "Tensorflow 2 available")
  set(TENSORFLOW_SOURCE_FILES
       ${CMAKE_SOURCE_DIR}/src/NeuralNetworkAbstractionLayer/neuralNetworkAbstraction.cpp
@@ -91,21 +114,46 @@ ENDIF()
 
 
 include_directories(${TENSORFLOW_INCLUDE_ROOT})
+include_directories(${CMAKE_SOURCE_DIR}/src)
 ADD_LIBRARY(TensorflowFramework SHARED IMPORTED) 
 
-IF (TENSORFLOW2_FOUND)
-  SET_TARGET_PROPERTIES(TensorflowFramework PROPERTIES IMPORTED_LOCATION ${TENSORFLOW_ROOT}/libtensorflow_framework.so.2) 
-ELSE(TENSORFLOW2_FOUND)
-  SET_TARGET_PROPERTIES(TensorflowFramework PROPERTIES IMPORTED_LOCATION ${TENSORFLOW_ROOT}/libtensorflow_framework.so) 
-ENDIF (TENSORFLOW2_FOUND)
+IF (WIN32)
+  IF (TENSORFLOW2_FOUND)
+    SET_TARGET_PROPERTIES(TensorflowFramework PROPERTIES
+      IMPORTED_IMPLIB ${TENSORFLOW_ROOT}/tensorflow_framework.lib
+      IMPORTED_LOCATION ${TENSORFLOW_ROOT}/tensorflow_framework.dll)
+  ELSE()
+    SET_TARGET_PROPERTIES(TensorflowFramework PROPERTIES
+      IMPORTED_IMPLIB ${TENSORFLOW_ROOT}/tensorflow_framework.lib
+      IMPORTED_LOCATION ${TENSORFLOW_ROOT}/tensorflow_framework.dll)
+  ENDIF()
+ELSE()
+  IF (TENSORFLOW2_FOUND)
+    SET_TARGET_PROPERTIES(TensorflowFramework PROPERTIES IMPORTED_LOCATION ${TENSORFLOW_ROOT}/libtensorflow_framework.so.2)
+  ELSE()
+    SET_TARGET_PROPERTIES(TensorflowFramework PROPERTIES IMPORTED_LOCATION ${TENSORFLOW_ROOT}/libtensorflow_framework.so)
+  ENDIF()
+ENDIF()
 
 ADD_LIBRARY(Tensorflow SHARED IMPORTED)
 
-IF (TENSORFLOW2_FOUND)
- SET_TARGET_PROPERTIES(Tensorflow PROPERTIES IMPORTED_LOCATION ${TENSORFLOW_ROOT}/libtensorflow.so.2)  
-ELSE(TENSORFLOW2_FOUND)
- SET_TARGET_PROPERTIES(Tensorflow PROPERTIES IMPORTED_LOCATION ${TENSORFLOW_ROOT}/libtensorflow.so)  
-ENDIF (TENSORFLOW2_FOUND)
+IF (WIN32)
+  IF (TENSORFLOW2_FOUND)
+    SET_TARGET_PROPERTIES(Tensorflow PROPERTIES
+      IMPORTED_IMPLIB ${TENSORFLOW_ROOT}/tensorflow.lib
+      IMPORTED_LOCATION ${TENSORFLOW_ROOT}/tensorflow.dll)
+  ELSE()
+    SET_TARGET_PROPERTIES(Tensorflow PROPERTIES
+      IMPORTED_IMPLIB ${TENSORFLOW_ROOT}/tensorflow.lib
+      IMPORTED_LOCATION ${TENSORFLOW_ROOT}/tensorflow.dll)
+  ENDIF()
+ELSE()
+  IF (TENSORFLOW2_FOUND)
+    SET_TARGET_PROPERTIES(Tensorflow PROPERTIES IMPORTED_LOCATION ${TENSORFLOW_ROOT}/libtensorflow.so.2)
+  ELSE()
+    SET_TARGET_PROPERTIES(Tensorflow PROPERTIES IMPORTED_LOCATION ${TENSORFLOW_ROOT}/libtensorflow.so)
+  ENDIF()
+ENDIF()
 
 
 
@@ -194,7 +242,11 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/dependencies/RGBDAcquisition/tools/Calibrat
 #add_subdirectory(${CMAKE_SOURCE_DIR}/dependencies/RGBDAcquisition/opengl_acquisition_shared_library) #OpenGLAcquisition
 add_definitions(-DUSE_OPENGL)
 #add_definitions(-DUSE_GLEW)
-set(OPENGL_LIBS  rt m GL GLU GLEW X11 Codecs CalibrationLibrary)
+if (WIN32)
+set(OPENGL_LIBS  ${MOCAPNET_POSIX_LIBS} opengl32 glu32 Codecs CalibrationLibrary)
+else()
+set(OPENGL_LIBS  ${MOCAPNET_POSIX_LIBS} GL GLU GLEW X11 Codecs CalibrationLibrary)
+endif()
 set(OPENGL_SOURCE 
               ${CMAKE_SOURCE_DIR}/dependencies/RGBDAcquisition/opengl_acquisition_shared_library/OpenGLAcquisition.c
               ${CMAKE_SOURCE_DIR}/dependencies/RGBDAcquisition/opengl_acquisition_shared_library/OpenGLAcquisition.h

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,0 +1,47 @@
+# Windows Build Notes
+
+This repository can be built with Microsoft Visual Studio 2022 and the NVIDIA CUDA toolchain on Windows. The project keeps the Linux layout, but adds shims and build logic so the same sources compile on MSVC.
+
+## Prerequisites
+
+1. **CMake** 3.24 or newer and a recent MSVC toolset.
+2. **TensorFlow C API for Windows** (GPU or CPU). Download the official `libtensorflow` archive (e.g. `libtensorflow-cpu-windows-x86_64-2.13.0.zip`) from [TensorFlow.org](https://www.tensorflow.org/install/lang_c) and extract it to:
+   ```text
+   dependencies/libtensorflow/
+   ├── include/
+   └── lib/
+       ├── tensorflow.dll
+       ├── tensorflow.lib
+       ├── tensorflow_framework.dll
+       └── tensorflow_framework.lib
+   ```
+   The repository’s CMake files will automatically pick up the vendored package when `tensorflow.dll` is present under `dependencies/libtensorflow/lib/`.
+3. **OpenCV** through [vcpkg](https://github.com/microsoft/vcpkg):
+   ```powershell
+   vcpkg install opencv:x64-windows
+   ```
+   Configure CMake with the vcpkg toolchain, for example:
+   ```powershell
+   cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE="C:/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake"
+   ```
+4. An NVIDIA driver compatible with the TensorFlow build you vendor.
+
+## Building
+
+```powershell
+cmake -B build -S . -A x64 -DCMAKE_TOOLCHAIN_FILE="C:/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake"
+cmake --build build --config Release
+```
+
+`_USE_MATH_DEFINES` and the Windows compatibility layer are configured automatically by the top-level `CMakeLists.txt`.
+
+## Notes
+
+- The `src/common/windows_compat.h` header provides implementations for `getline`, `ssize_t`, case-insensitive string helpers, and timing shims that are missing on Windows.
+- ANSI color escape sequences are disabled on the Windows console via a shared `console_colors.h` header.
+- POSIX-only link libraries (`rt`, `dl`, `m`, `pthread`) are wrapped behind the `MOCAPNET_POSIX_LIBS` variable so that they are not linked when building with MSVC.
+- TensorFlow and TensorFlow Framework imported targets now point to `.dll`/`.lib` pairs when `WIN32` is defined.
+
+## Optional
+
+- To keep third-party dependencies reproducible you can create a `vcpkg.json` manifest with the desired ports and use manifest mode (`vcpkg install --feature-flags=manifests`).

--- a/src/GroundTruthGenerator/CMakeLists.txt
+++ b/src/GroundTruthGenerator/CMakeLists.txt
@@ -10,7 +10,7 @@ ${CMAKE_SOURCE_DIR}/dependencies/RGBDAcquisition/opengl_acquisition_shared_libra
 ${BVH_SOURCE}
               )
  
-target_link_libraries(GroundTruthDumper rt m pthread ) 
+target_link_libraries(GroundTruthDumper ${MOCAPNET_POSIX_LIBS})
 #add_dependencies(GroundTruthDumper OGLRendererSandbox)  
        
  

--- a/src/HelloWorld/CMakeLists.txt
+++ b/src/HelloWorld/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.5)
 #-----------------------------------------------
 project( helloWorld )  
 add_executable(helloWorld main.cpp)   
-target_link_libraries(helloWorld rt dl m )
+target_link_libraries(helloWorld ${MOCAPNET_POSIX_LIBS} )
 set_target_properties(helloWorld PROPERTIES DEBUG_POSTFIX "D") 
 set_target_properties(helloWorld PROPERTIES 
                        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/src/JointEstimator2D/CMakeLists.txt
+++ b/src/JointEstimator2D/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
             ${CMAKE_SOURCE_DIR}/src/Tensorflow/tf_utils.cpp
            )
 
-target_link_libraries(JointEstimator2D rt dl m Tensorflow TensorflowFramework )
+target_link_libraries(JointEstimator2D ${MOCAPNET_POSIX_LIBS} Tensorflow TensorflowFramework )
 set_target_properties(JointEstimator2D PROPERTIES DEBUG_POSTFIX "D") 
        
 
@@ -33,7 +33,7 @@ find_package(OpenCV REQUIRED)
 INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
 
 add_executable(WebcamAnd2DJoints webcamAnd2DJoints.cpp)   
-target_link_libraries(WebcamAnd2DJoints rt dl m ${OpenCV_LIBRARIES} JointEstimator2D  Tensorflow  TensorflowFramework)
+target_link_libraries(WebcamAnd2DJoints ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES} JointEstimator2D  Tensorflow  TensorflowFramework)
 set_target_properties(WebcamAnd2DJoints PROPERTIES DEBUG_POSTFIX "D") 
        
 

--- a/src/MocapNET2/BVHGUI2/CMakeLists.txt
+++ b/src/MocapNET2/BVHGUI2/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories(${TENSORFLOW_INCLUDE_ROOT})
 add_executable(BVHGUI2 bvhGUI2.cpp 
 ${BVH_SOURCE} )
 
-target_link_libraries(BVHGUI2 rt dl m ${OpenCV_LIBRARIES} ${OPENGL_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 )
+target_link_libraries(BVHGUI2 ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES} ${OPENGL_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 )
 set_target_properties(BVHGUI2 PROPERTIES DEBUG_POSTFIX "D") 
 
 

--- a/src/MocapNET2/BVHGUI2/bvhGUI2.cpp
+++ b/src/MocapNET2/BVHGUI2/bvhGUI2.cpp
@@ -18,11 +18,7 @@
 #include "../../../dependencies/RGBDAcquisition/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_rename.h"
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 using namespace cv;

--- a/src/MocapNET2/BVHTemplate/CMakeLists.txt
+++ b/src/MocapNET2/BVHTemplate/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules ${CMAKE_MODUL
 
 add_executable(BVHTemplate  main.c ${BVH_SOURCE} )
  
-target_link_libraries(BVHTemplate rt m pthread ) 
+target_link_libraries(BVHTemplate ${MOCAPNET_POSIX_LIBS})
 #add_dependencies(BVHTemplate OGLRendererSandbox)  
        
  

--- a/src/MocapNET2/CSVClusterPlot/CMakeLists.txt
+++ b/src/MocapNET2/CSVClusterPlot/CMakeLists.txt
@@ -17,7 +17,7 @@ perform3DClustering.cpp
 ${BVH_SOURCE}
 )
 
-target_link_libraries(CSVClusterPlot rt dl m ${OpenCV_LIBRARIES} ${OPENGL_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 )
+target_link_libraries(CSVClusterPlot ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES} ${OPENGL_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 )
 #set_target_properties(CSVClusterPlot PROPERTIES DEBUG_POSTFIX "D") 
 
 

--- a/src/MocapNET2/CSVClusterPlot/csvClusterPlot.cpp
+++ b/src/MocapNET2/CSVClusterPlot/csvClusterPlot.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 
 #include <sys/stat.h> //mkdir
+#include "common/windows_compat.h"
 #include "../MocapNETLib2/mocapnet2.hpp"
 #include "../MocapNETLib2/IO/bvh.hpp"
 #include "../MocapNETLib2/visualization/visualization.hpp"

--- a/src/MocapNET2/CSVClusterPlot/perform3DClustering.cpp
+++ b/src/MocapNET2/CSVClusterPlot/perform3DClustering.cpp
@@ -10,14 +10,10 @@
 #include "../../../dependencies/RGBDAcquisition/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_filter.h"
 #include "../../../dependencies/RGBDAcquisition/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_rename.h"
 #include "../../../dependencies/RGBDAcquisition/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_randomize.h"
+#include "common/console_colors.h"
 
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 int appendBVHVectorToFile(FILE * fp, std::vector<float> vec)
 {

--- a/src/MocapNET2/Converters/H36M/CMakeLists.txt
+++ b/src/MocapNET2/Converters/H36M/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(
 
 #-----------------------------------------------
 
-target_link_libraries(convertH36GroundTruthToMocapNETInput rt dl m pthread MocapNETLib2)
+target_link_libraries(convertH36GroundTruthToMocapNETInput ${MOCAPNET_POSIX_LIBS} MocapNETLib2)
 set_target_properties(convertH36GroundTruthToMocapNETInput PROPERTIES DEBUG_POSTFIX "D") 
 set_target_properties(convertH36GroundTruthToMocapNETInput PROPERTIES 
                        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/src/MocapNET2/Converters/H36M/convertH36GroundTruthToMocapNETInput.cpp
+++ b/src/MocapNET2/Converters/H36M/convertH36GroundTruthToMocapNETInput.cpp
@@ -14,6 +14,7 @@
 #include "../../../MocapNET2/MocapNETLib2/IO/jsonRead.hpp"
 #include "../../../MocapNET2/MocapNETLib2/IO/csvRead.hpp"
 #include "../../../MocapNET2/MocapNETLib2/IO/csvWrite.hpp"
+#include "common/console_colors.h"
 
 
 #if USE_BVH
@@ -27,11 +28,6 @@
 #endif // USE_BVH
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 

--- a/src/MocapNET2/Converters/Openpose/CMakeLists.txt
+++ b/src/MocapNET2/Converters/Openpose/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(
 
 #-----------------------------------------------
    
-target_link_libraries(convertOpenPoseJSONToCSV rt dl m pthread MocapNETLib2)
+target_link_libraries(convertOpenPoseJSONToCSV ${MOCAPNET_POSIX_LIBS} MocapNETLib2)
 set_target_properties(convertOpenPoseJSONToCSV PROPERTIES DEBUG_POSTFIX "D") 
 set_target_properties(convertOpenPoseJSONToCSV PROPERTIES 
                        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/src/MocapNET2/Converters/Openpose/convertOpenPoseJSONToCSV.cpp
+++ b/src/MocapNET2/Converters/Openpose/convertOpenPoseJSONToCSV.cpp
@@ -60,12 +60,8 @@
 #include "../../../MocapNET2/MocapNETLib2/IO/jsonRead.hpp"
 #include "../../../MocapNET2/MocapNETLib2/IO/csvRead.hpp"
 #include "../../../MocapNET2/MocapNETLib2/IO/csvWrite.hpp"
+#include "common/console_colors.h"
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 int  findFirstJSONFileInDirectory(const char * path,const char * formatString, const char * label, unsigned int * frameIDOutput)

--- a/src/MocapNET2/Converters/convertCSV3D/CMakeLists.txt
+++ b/src/MocapNET2/Converters/convertCSV3D/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(
 
 #-----------------------------------------------
 
-target_link_libraries(convertCSV3DToMocapNETInput rt dl m pthread MocapNETLib2)
+target_link_libraries(convertCSV3DToMocapNETInput ${MOCAPNET_POSIX_LIBS} MocapNETLib2)
 set_target_properties(convertCSV3DToMocapNETInput PROPERTIES DEBUG_POSTFIX "D") 
 set_target_properties(convertCSV3DToMocapNETInput PROPERTIES 
                        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/src/MocapNET2/Converters/convertCSV3D/convertCSV3DToMocapNETInput.cpp
+++ b/src/MocapNET2/Converters/convertCSV3D/convertCSV3DToMocapNETInput.cpp
@@ -14,6 +14,7 @@
 #include "../../../MocapNET2/MocapNETLib2/IO/jsonRead.hpp"
 #include "../../../MocapNET2/MocapNETLib2/IO/csvRead.hpp"
 #include "../../../MocapNET2/MocapNETLib2/IO/csvWrite.hpp"
+#include "common/console_colors.h"
 
 
 #if USE_BVH
@@ -27,11 +28,6 @@
 #endif // USE_BVH
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 

--- a/src/MocapNET2/HandOnlyTest/CMakeLists.txt
+++ b/src/MocapNET2/HandOnlyTest/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(OpenCV REQUIRED)
 INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
 
 add_executable(HandOnlyTest handTest.cpp)   
-target_link_libraries(HandOnlyTest rt dl m ${OpenCV_LIBRARIES}  Tensorflow  TensorflowFramework MocapNETLib2 )
+target_link_libraries(HandOnlyTest ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES}  Tensorflow  TensorflowFramework MocapNETLib2 )
 set_target_properties(HandOnlyTest PROPERTIES DEBUG_POSTFIX "D") 
        
 

--- a/src/MocapNET2/HandOnlyTest/handTest.cpp
+++ b/src/MocapNET2/HandOnlyTest/handTest.cpp
@@ -8,7 +8,10 @@
 #include <vector>
 #include <math.h>
 #include <string.h>
+#include "common/console_colors.h"
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "../MocapNETLib2/applicationLogic/parseCommandlineOptions.hpp"
 
@@ -41,11 +44,6 @@
 #include "../../../dependencies/RGBDAcquisition/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/ik/hardcodedProblems_inverseKinematics.h"
  
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 unsigned int myMin(unsigned int a,unsigned int b)

--- a/src/MocapNET2/MocapNET2LiveWebcamDemo/CMakeLists.txt
+++ b/src/MocapNET2/MocapNET2LiveWebcamDemo/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories(${TENSORFLOW_INCLUDE_ROOT})
 
 add_executable(MocapNET2LiveWebcamDemo livedemo.cpp  )
 
-target_link_libraries(MocapNET2LiveWebcamDemo rt dl m ${OpenCV_LIBRARIES} ${OPENGL_LIBS} JointEstimator2D Tensorflow TensorflowFramework MocapNETLib2 ${NETWORK_CLIENT_LIBRARIES} ${PNG_Libs} ${JPG_Libs} )
+target_link_libraries(MocapNET2LiveWebcamDemo ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES} ${OPENGL_LIBS} JointEstimator2D Tensorflow TensorflowFramework MocapNETLib2 ${NETWORK_CLIENT_LIBRARIES} ${PNG_Libs} ${JPG_Libs} )
 set_target_properties(MocapNET2LiveWebcamDemo PROPERTIES DEBUG_POSTFIX "D") 
 
 

--- a/src/MocapNET2/MocapNET2LiveWebcamDemo/livedemo.cpp
+++ b/src/MocapNET2/MocapNET2LiveWebcamDemo/livedemo.cpp
@@ -5,7 +5,10 @@
  *  @author Ammar Qammaz (AmmarkoV)
  */
 #include <stdio.h>
+#include "common/console_colors.h"
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 //-----------------------------------------------------------------
 #include "../../JointEstimator2D/cameraControl.hpp"
 #include "../../JointEstimator2D/jointEstimator2D.hpp"
@@ -27,11 +30,6 @@
 using namespace cv;
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 int main(int argc, char *argv[])

--- a/src/MocapNET2/MocapNETFromCSV/CMakeLists.txt
+++ b/src/MocapNET2/MocapNETFromCSV/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(OpenCV REQUIRED)
 INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
 
 add_executable(MocapNET2CSV  mocapnet2CSV.cpp  )   
-target_link_libraries(MocapNET2CSV rt dl m ${OpenCV_LIBRARIES}  Tensorflow  TensorflowFramework MocapNETLib2 )
+target_link_libraries(MocapNET2CSV ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES}  Tensorflow  TensorflowFramework MocapNETLib2 )
 set_target_properties(MocapNET2CSV PROPERTIES DEBUG_POSTFIX "D") 
        
 

--- a/src/MocapNET2/MocapNETFromCSV/mocapnet2CSV.cpp
+++ b/src/MocapNET2/MocapNETFromCSV/mocapnet2CSV.cpp
@@ -8,7 +8,10 @@
 #include <vector>
 #include <math.h>
 #include <string.h>
+#include "common/console_colors.h"
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "../MocapNETLib2/applicationLogic/parseCommandlineOptions.hpp"
 
@@ -26,11 +29,6 @@
 #include "../MocapNETLib2/IO/skeletonAbstraction.hpp"
 //---------------------------------------------------
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 

--- a/src/MocapNET2/MocapNETLib2/CMakeLists.txt
+++ b/src/MocapNET2/MocapNETLib2/CMakeLists.txt
@@ -60,7 +60,7 @@ ${TENSORFLOW_SOURCE_FILES}
 )   
 
 
-target_link_libraries(MocapNETLib2 rt dl m pthread ${OpenCV_LIBRARIES} ${OPENGL_LIBS} Tensorflow TensorflowFramework ${NETWORK_CLIENT_LIBRARIES} ${PNG_Libs} ${JPG_Libs} )
+target_link_libraries(MocapNETLib2 ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES} ${OPENGL_LIBS} Tensorflow TensorflowFramework ${NETWORK_CLIENT_LIBRARIES} ${PNG_Libs} ${JPG_Libs} )
 set_target_properties(MocapNETLib2 PROPERTIES DEBUG_POSTFIX "D") 
        
 

--- a/src/MocapNET2/MocapNETLib2/IO/bvh.cpp
+++ b/src/MocapNET2/MocapNETLib2/IO/bvh.cpp
@@ -7,12 +7,7 @@
 #include "skeletonSerializedToBVHTransform.hpp"
 #include "../mocapnet2.hpp"
 #include "../visualization/opengl.hpp"
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 #if USE_BVH

--- a/src/MocapNET2/MocapNETLib2/IO/conversions.cpp
+++ b/src/MocapNET2/MocapNETLib2/IO/conversions.cpp
@@ -7,12 +7,7 @@
 
 #include "csvRead.hpp"
 #include "../../../../dependencies/RGBDAcquisition/tools/AmMatrix/matrix4x4Tools.h"
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 int appendVectorToFile(const char * filename, std::vector<float> vec)

--- a/src/MocapNET2/MocapNETLib2/IO/csvRead.cpp
+++ b/src/MocapNET2/MocapNETLib2/IO/csvRead.cpp
@@ -11,12 +11,7 @@
 #include "../../MocapNETLib2/IO/jsonMocapNETHelpers.hpp"
 
 #include "../../../../dependencies/InputParser/InputParser_C.h"
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 

--- a/src/MocapNET2/MocapNETLib2/IO/jsonMocapNETHelpers.cpp
+++ b/src/MocapNET2/MocapNETLib2/IO/jsonMocapNETHelpers.cpp
@@ -3,13 +3,7 @@
 #include <string.h>
 
 #include "../../MocapNETLib2/IO/bvh.hpp"
-
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 int bothZero(float a,float b)

--- a/src/MocapNET2/MocapNETLib2/IO/jsonRead.cpp
+++ b/src/MocapNET2/MocapNETLib2/IO/jsonRead.cpp
@@ -1,20 +1,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <math.h>
 
 
 #include "jsonRead.hpp"
 #include "../../../../dependencies/InputParser/InputParser_C.h"
+#include "common/console_colors.h"
 
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 float checkSkeletonDistance(struct skeletonStructure * PreviousSkelA,struct skeletonStructure * skelB)

--- a/src/MocapNET2/MocapNETLib2/IO/skeletonAbstraction.cpp
+++ b/src/MocapNET2/MocapNETLib2/IO/skeletonAbstraction.cpp
@@ -8,13 +8,7 @@
 #include <vector>
 #include <math.h>
 #include <string.h>
- 
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 #include <ctype.h> //toupper

--- a/src/MocapNET2/MocapNETLib2/applicationLogic/artifactRecognition.cpp
+++ b/src/MocapNET2/MocapNETLib2/applicationLogic/artifactRecognition.cpp
@@ -2,18 +2,14 @@
 
 #include "../../../../dependencies/InputParser/InputParser_C.h"
 #include "../../../../dependencies/RGBDAcquisition/tools/AmMatrix/matrixCalculations.h"
+#include "common/console_colors.h"
 
 
- #include <iostream> 
- 
- 
+ #include <iostream>
+
+
 #include <stdio.h>
- 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+
  
  
  int initializeArtifactsFromFile(struct sceneArtifacts * scene,const char * filename)

--- a/src/MocapNET2/MocapNETLib2/applicationLogic/gestureRecognition.cpp
+++ b/src/MocapNET2/MocapNETLib2/applicationLogic/gestureRecognition.cpp
@@ -4,13 +4,7 @@
 #include "../IO/bvh.hpp"
 #include "../IO/csvRead.hpp"
 #include "poseRecognition.hpp"
-
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 int addToMotionHistory(struct PoseHistory * poseHistoryStorage,std::vector<float> pose)
 {

--- a/src/MocapNET2/MocapNETLib2/applicationLogic/parseCommandlineOptions.cpp
+++ b/src/MocapNET2/MocapNETLib2/applicationLogic/parseCommandlineOptions.cpp
@@ -1,7 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "common/console_colors.h"
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "../mocapnet2.hpp"
 #include "parseCommandlineOptions.hpp"
@@ -14,11 +17,6 @@
 
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 const char   outputPathStatic[]="out.bvh";
 

--- a/src/MocapNET2/MocapNETLib2/applicationLogic/poseRecognition.cpp
+++ b/src/MocapNET2/MocapNETLib2/applicationLogic/poseRecognition.cpp
@@ -3,13 +3,7 @@
 #include "../tools.hpp"
 #include "../IO/bvh.hpp"
 #include "../IO/csvRead.hpp"
-
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 

--- a/src/MocapNET2/MocapNETLib2/core/core.cpp
+++ b/src/MocapNET2/MocapNETLib2/core/core.cpp
@@ -18,16 +18,12 @@
 #include "../../MocapNETLib2/solutionParts/body.hpp"
 #include "../../MocapNETLib2/solutionParts/upperBody.hpp"
 #include "../../MocapNETLib2/solutionParts/lowerBody.hpp"
+#include "common/console_colors.h"
 //----------------------------------------------
 #include "../../MocapNETLib2/core/singleThreaded.hpp"
 #include "../../MocapNETLib2/core/multiThreaded.hpp"
 //----------------------------------------------
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 float undoOrientationTrickForBackOrientation(float orientation)

--- a/src/MocapNET2/MocapNETLib2/core/singleThreaded.cpp
+++ b/src/MocapNET2/MocapNETLib2/core/singleThreaded.cpp
@@ -1,12 +1,6 @@
 #include "singleThreaded.hpp"
 #include "core.hpp"
-
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 

--- a/src/MocapNET2/MocapNETLib2/mocapnet2.cpp
+++ b/src/MocapNET2/MocapNETLib2/mocapnet2.cpp
@@ -12,12 +12,7 @@
 //----------------------------------------------
 
 #include <string.h>
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 
 int registerGestureEventCallbackWithMocapNET(struct MocapNET2 * mnet,void * callback)

--- a/src/MocapNET2/MocapNETLib2/solutionParts/body.cpp
+++ b/src/MocapNET2/MocapNETLib2/solutionParts/body.cpp
@@ -4,12 +4,7 @@
 #include "../../MocapNETLib2/IO/conversions.hpp"
 #include "../../MocapNETLib2/tools.hpp"
 #include "../../MocapNETLib2/core/core.hpp"
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 int mocapnetBody_initializeAssociations(struct MocapNET2 * mnet, struct skeletonSerialized * input)
 {

--- a/src/MocapNET2/MocapNETLib2/solutionParts/lowerBody.cpp
+++ b/src/MocapNET2/MocapNETLib2/solutionParts/lowerBody.cpp
@@ -4,12 +4,7 @@
 #include "../../MocapNETLib2/IO/conversions.hpp"
 #include "../../MocapNETLib2/tools.hpp"
 #include "../../MocapNETLib2/core/core.hpp"
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 int mocapnetLowerBody_initializeAssociations(struct MocapNET2 * mnet, struct skeletonSerialized * input)
 {

--- a/src/MocapNET2/MocapNETLib2/solutionParts/upperBody.cpp
+++ b/src/MocapNET2/MocapNETLib2/solutionParts/upperBody.cpp
@@ -7,13 +7,7 @@
 #include "../tools.hpp"
 
 #include "../visualization/visualization.hpp" //debug alignment
-
-
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
+#include "common/console_colors.h"
 
 int mocapnetUpperBody_initializeAssociations(struct MocapNET2 * mnet, struct skeletonSerialized * input)
 {

--- a/src/MocapNET2/MocapNETLib2/tools.cpp
+++ b/src/MocapNET2/MocapNETLib2/tools.cpp
@@ -1,8 +1,16 @@
 #include "tools.hpp"
 
+#include "common/windows_compat.h"
+#include "common/console_colors.h"
+
+#ifndef _WIN32
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#else
+#include <sys/stat.h>
+#include <windows.h>
+#endif
 #include <time.h>
 #include <stdio.h>
 #include <math.h>
@@ -14,11 +22,6 @@
 unsigned long tickBaseMN = 0;
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
  
 
 int vectorcmp(std::vector<float> vA,std::vector<float> vB, float maximumDistance)
@@ -48,12 +51,23 @@ int vectorcmp(std::vector<float> vA,std::vector<float> vB, float maximumDistance
 
 int nsleep(long nanoseconds)
 {
+#ifdef _WIN32
+   if (nanoseconds <= 0)
+   {
+      return 0;
+   }
+   struct timespec req;
+   req.tv_sec = (long)(nanoseconds / 1000000000L);
+   req.tv_nsec = nanoseconds % 1000000000L;
+   return nanosleep(&req, NULL);
+#else
    struct timespec req, rem;
 
-   req.tv_sec = 0;              
-   req.tv_nsec = nanoseconds; 
+   req.tv_sec = 0;
+   req.tv_nsec = nanoseconds;
 
    return nanosleep(&req , &rem);
+#endif
 }
 
 

--- a/src/MocapNET2/MocapNETLib2/visualization/opengl.cpp
+++ b/src/MocapNET2/MocapNETLib2/visualization/opengl.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include "opengl.hpp"
 #include "../mocapnet2.hpp"
+#include "common/console_colors.h"
 
 #if USE_OPENGL
  int openGLHasInitialization=0;
@@ -8,11 +9,6 @@
  #include "../../../../dependencies/RGBDAcquisition/opengl_acquisition_shared_library/OpenGLAcquisition.h"
 #endif
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 int initializeOpenGLStuff(unsigned int openGLFrameWidth,unsigned int openGLFrameHeight)

--- a/src/MocapNET2/MocapNETLib2/visualization/visualization.cpp
+++ b/src/MocapNET2/MocapNETLib2/visualization/visualization.cpp
@@ -16,14 +16,10 @@ using namespace cv;
 #include "../IO/bvh.hpp"
 #include "../tools.hpp"
 #include "../mocapnet2.hpp"
+#include "common/console_colors.h"
 //#include "../MocapNETLib2/NSDM/legacyNSDM.hpp"
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 std::vector<cv::Point> leftEndEffector;
 std::vector<cv::Point> rightEndEffector;

--- a/src/MocapNET2/drawCSV/CMakeLists.txt
+++ b/src/MocapNET2/drawCSV/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories(${TENSORFLOW_INCLUDE_ROOT})
 
 add_executable(drawCSV drawCSV.cpp  )
 
-target_link_libraries(drawCSV rt dl m ${OpenCV_LIBRARIES} ${OPENGL_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 ${NETWORK_CLIENT_LIBRARIES} ${PNG_Libs} ${JPG_Libs} )
+target_link_libraries(drawCSV ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES} ${OPENGL_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 ${NETWORK_CLIENT_LIBRARIES} ${PNG_Libs} ${JPG_Libs} )
 set_target_properties(drawCSV PROPERTIES DEBUG_POSTFIX "D") 
 
 

--- a/src/MocapNET2/reshapeCSVFileToMakeClassification/CMakeLists.txt
+++ b/src/MocapNET2/reshapeCSVFileToMakeClassification/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required( VERSION 2.8.13 )
 
 
 add_executable(ReshapeCSV reshapeCSV.cpp )   
-target_link_libraries(ReshapeCSV rt dl m Tensorflow  TensorflowFramework MocapNETLib2 )
+target_link_libraries(ReshapeCSV ${MOCAPNET_POSIX_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 )
 #set_target_properties(TestCSV PROPERTIES DEBUG_POSTFIX "D") 
        
 

--- a/src/MocapNET2/reshapeCSVFileToMakeClassification/reshapeCSV.cpp
+++ b/src/MocapNET2/reshapeCSVFileToMakeClassification/reshapeCSV.cpp
@@ -7,7 +7,10 @@
 #include <vector>
 #include <math.h>
 #include <string.h>
+#include "common/windows_compat.h"
+#ifndef _WIN32
 #include <unistd.h>
+#endif
  
 #include "../MocapNETLib2/mocapnet2.hpp" 
 #include "../MocapNETLib2/core/core.hpp" 

--- a/src/MocapNET2/testCSV/CMakeLists.txt
+++ b/src/MocapNET2/testCSV/CMakeLists.txt
@@ -8,7 +8,7 @@ INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
 
 
 add_executable(TestCSV testCSV.cpp )   
-target_link_libraries(TestCSV rt dl m Tensorflow  TensorflowFramework MocapNETLib2 )
+target_link_libraries(TestCSV ${MOCAPNET_POSIX_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 )
 #set_target_properties(TestCSV PROPERTIES DEBUG_POSTFIX "D") 
        
 

--- a/src/MocapNET2/testCSV/testCSV.cpp
+++ b/src/MocapNET2/testCSV/testCSV.cpp
@@ -7,7 +7,10 @@
 #include <vector>
 #include <math.h>
 #include <string.h>
+#include "common/windows_compat.h"
+#ifndef _WIN32
 #include <unistd.h>
+#endif
  
 #include "../MocapNETLib2/mocapnet2.hpp" 
 #include "../MocapNETLib2/IO/csvRead.hpp" 

--- a/src/Tensorflow2/CMakeLists.txt
+++ b/src/Tensorflow2/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required( VERSION 2.8.7 )
  
 
 add_executable(Tensorflow2  testtf2.cpp tensorflow2.h )   
-target_link_libraries(Tensorflow2 rt dl m Tensorflow  TensorflowFramework MocapNETLib2 )
+target_link_libraries(Tensorflow2 ${MOCAPNET_POSIX_LIBS} Tensorflow  TensorflowFramework MocapNETLib2 )
 set_target_properties(Tensorflow2 PROPERTIES DEBUG_POSTFIX "D") 
        
 

--- a/src/Tensorflow2/testtf2.cpp
+++ b/src/Tensorflow2/testtf2.cpp
@@ -1,17 +1,14 @@
 #include <stdlib.h>
 #include <stdio.h> 
 #include <string.h> 
-#include <math.h> 
+#include <math.h>
 #include <vector>
+#include "common/windows_compat.h"
+#include "common/console_colors.h"
 
 #include "tensorflow2.h"
 
 
-#define NORMAL   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
 
 
 float rand_FloatRange(float a, float b)
@@ -138,7 +135,9 @@ int testUpperBody()
 
 
 
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 int executeCommandLineAndRetreiveAllResults(const char *  command , char * what2GetBack , unsigned int what2GetBackMaxSize, unsigned long * what2GetBackSize)
 {
  /* Open the command for reading. */

--- a/src/Webcam/CMakeLists.txt
+++ b/src/Webcam/CMakeLists.txt
@@ -7,7 +7,7 @@ INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
  
 
 add_executable(OpenCVTest webcam.cpp)   
-target_link_libraries(OpenCVTest rt dl m ${OpenCV_LIBRARIES}    )
+target_link_libraries(OpenCVTest ${MOCAPNET_POSIX_LIBS} ${OpenCV_LIBRARIES}    )
 set_target_properties(OpenCVTest PROPERTIES DEBUG_POSTFIX "D") 
        
 

--- a/src/common/console_colors.h
+++ b/src/common/console_colors.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "windows_compat.h"
+
+#ifdef _WIN32
+#define NORMAL ""
+#define BLACK  ""
+#define RED    ""
+#define GREEN  ""
+#define YELLOW ""
+#else
+#define NORMAL   "\033[0m"
+#define BLACK   "\033[30m"
+#define RED     "\033[31m"
+#define GREEN   "\033[32m"
+#define YELLOW  "\033[33m"
+#endif

--- a/src/common/windows_compat.h
+++ b/src/common/windows_compat.h
@@ -1,0 +1,130 @@
+#ifndef WINDOWS_COMPAT_H
+#define WINDOWS_COMPAT_H
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <BaseTsd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+
+#ifndef HAVE_STRUCT_TIMESPEC
+#define HAVE_STRUCT_TIMESPEC
+struct timespec
+{
+    long tv_sec;
+    long tv_nsec;
+};
+#endif
+
+#ifndef ssize_t
+typedef SSIZE_T ssize_t;
+#endif
+
+static ssize_t portable_getline(char **lineptr, size_t *n, FILE *stream)
+{
+    if (!lineptr || !n || !stream)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (*lineptr == NULL || *n == 0)
+    {
+        size_t initial_size = (*n > 0) ? *n : 128;
+        char *new_ptr = (char *)malloc(initial_size);
+        if (!new_ptr)
+        {
+            errno = ENOMEM;
+            return -1;
+        }
+        *lineptr = new_ptr;
+        *n = initial_size;
+    }
+
+    size_t position = 0;
+    int ch = 0;
+
+    while ((ch = fgetc(stream)) != EOF)
+    {
+        if (position + 1 >= *n)
+        {
+            size_t new_size = (*n) * 2;
+            char *new_ptr = (char *)realloc(*lineptr, new_size);
+            if (!new_ptr)
+            {
+                errno = ENOMEM;
+                return -1;
+            }
+            *lineptr = new_ptr;
+            *n = new_size;
+        }
+
+        (*lineptr)[position++] = (char)ch;
+
+        if (ch == '\n')
+        {
+            break;
+        }
+    }
+
+    if (position == 0 && ch == EOF)
+    {
+        return -1;
+    }
+
+    (*lineptr)[position] = '\0';
+    return (ssize_t)position;
+}
+
+#define getline portable_getline
+
+#ifndef strdup
+#define strdup _strdup
+#endif
+
+#ifndef strcasecmp
+#define strcasecmp _stricmp
+#endif
+
+#ifndef strncasecmp
+#define strncasecmp _strnicmp
+#endif
+
+#ifndef popen
+#define popen _popen
+#endif
+
+#ifndef pclose
+#define pclose _pclose
+#endif
+
+static inline int nanosleep_compat(const struct timespec *req, struct timespec *rem)
+{
+    (void)rem;
+    if (!req)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    long long total_ns = (long long)req->tv_sec * 1000000000LL + req->tv_nsec;
+    if (total_ns <= 0)
+    {
+        return 0;
+    }
+
+    DWORD milliseconds = (DWORD)((total_ns + 999999LL) / 1000000LL);
+    Sleep(milliseconds);
+    return 0;
+}
+
+#define nanosleep nanosleep_compat
+
+#endif /* _WIN32 */
+
+#endif /* WINDOWS_COMPAT_H */

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "mocapnet",
+  "version": "0.0.1",
+  "dependencies": [
+    "opencv"
+  ]
+}


### PR DESCRIPTION
## Summary
- detect a vendored TensorFlow 2 Windows runtime in the top-level build and wrap POSIX-only link dependencies behind a reusable variable
- add shared Windows portability headers for getline, ssize_t, nanosleep, and ANSI colour shims and include them across MocapNET modules
- document Windows setup steps alongside a vcpkg manifest to simplify installing OpenCV on MSVC builds

## Testing
- `cmake -S . -B build` *(fails: OpenCV package not available in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a510bce88329af1a9272bcfd8321