### PR TITLE
Improve Windows dependency guidance

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -4,7 +4,7 @@ This repository can be built with Microsoft Visual Studio 2022 and the NVIDIA CU
 
 ## Prerequisites
 
-1. **CMake** 3.24 or newer and a recent MSVC toolset.
+1. **Visual Studio 2022** with the **Desktop development with C++** workload (provides the MSVC toolset) and **CMake** 3.24 or newer.
 2. **TensorFlow C API for Windows** (GPU or CPU). Download the official `libtensorflow` archive (e.g. `libtensorflow-cpu-windows-x86_64-2.13.0.zip`) from [TensorFlow.org](https://www.tensorflow.org/install/lang_c) and extract it to:
    ```text
    dependencies/libtensorflow/
@@ -16,9 +16,9 @@ This repository can be built with Microsoft Visual Studio 2022 and the NVIDIA CU
        └── tensorflow_framework.lib
    ```
    The repository’s CMake files will automatically pick up the vendored package when `tensorflow.dll` is present under `dependencies/libtensorflow/lib/`.
-3. **OpenCV** through [vcpkg](https://github.com/microsoft/vcpkg):
+3. **OpenCV** through [vcpkg](https://github.com/microsoft/vcpkg). The repository ships with a `vcpkg.json` manifest, so running the helper script or invoking vcpkg from the repository root automatically installs the required ports:
    ```powershell
-   vcpkg install opencv:x64-windows
+   vcpkg install --triplet x64-windows
    ```
    Configure CMake with the vcpkg toolchain, for example:
    ```powershell

--- a/build_install.bat
+++ b/build_install.bat
@@ -213,6 +213,9 @@ set "VCPKG_ROOT=%SCRIPT_ROOT%\dependencies\vcpkg"
 set "VCPKG_TOOLCHAIN=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"
 set "VCPKG_DEFAULT_TRIPLET=x64-windows"
 
+call :findVisualStudio
+if errorlevel 1 exit /b 1
+
 rem Install dependencies via vcpkg (manifest aware)
 if exist "%SCRIPT_ROOT%\vcpkg.json" (
     echo [*] Installing vcpkg manifest dependencies for triplet x64-windows
@@ -226,8 +229,6 @@ if errorlevel 1 (
     exit /b 1
 )
 
-call :findVisualStudio
-if errorlevel 1 exit /b 1
 exit /b 0
 
 :findVisualStudio


### PR DESCRIPTION
## Summary
- run the Visual Studio detection before invoking vcpkg in the Windows helper script to surface missing toolchains earlier
- document the Visual Studio requirement and manifest-based vcpkg workflow in the Windows build guide

## Testing
- not run (Windows helper script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5e41aa6108329b7d6185676ac3a15